### PR TITLE
Breaking update to attachments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "prefer-stable": true,
     "extra": {
         "branch-alias": {
-            "dev-master": "0.5.x-dev"
+            "dev-master": "0.6.x-dev"
         }
     },
     "require": {

--- a/src/Charcoal/Attachment/Object/Attachment.php
+++ b/src/Charcoal/Attachment/Object/Attachment.php
@@ -55,23 +55,6 @@ class Attachment extends Content implements AttachableInterface
     const CONTAINER_TYPE = AttachmentContainer::class;
 
     /**
-     * Glyphicons (from Bootstrap) for each of the default attachment types.
-     *
-     * @var array
-     */
-    protected $glyphs = [
-        'embed'     => 'glyphicon-blackboard',
-        'video'     => 'glyphicon-film',
-        'image'     => 'glyphicon-picture',
-        'file'      => 'glyphicon-file',
-        'link'      => 'glyphicon-link',
-        'text'      => 'glyphicon-font',
-        'gallery'   => 'glyphicon-duplicate',
-        'container' => 'glyphicon-list',
-        'accordion' => 'glyphicon-list'
-    ];
-
-    /**
      * The attachment type.
      *
      * @var string
@@ -366,22 +349,6 @@ class Attachment extends Content implements AttachableInterface
     }
 
     /**
-     * Retrieve the glyphicon for the current attachment type.
-     *
-     * @return string
-     */
-    public function glyphicon()
-    {
-        $type = $this->microType();
-
-        if (isset($this->glyphs[$type])) {
-            return $this->glyphs[$type];
-        }
-
-        return '';
-    }
-
-    /**
      * Retrieve the attachment's heading template.
      *
      * @return Translation|string|null
@@ -549,8 +516,6 @@ class Attachment extends Content implements AttachableInterface
     {
         return ($this instanceof AttachmentContainerInterface);
     }
-
-
 
     // Setters
     // =============================================================================

--- a/templates/charcoal/admin/widget/attachment/header.mustache
+++ b/templates/charcoal/admin/widget/attachment/header.mustache
@@ -1,5 +1,5 @@
 <div class="btn-toolbar" role="toolbar">
-    {{^ readOnly }}
+    {{^ attachmentOptions.read_only }}
     {{# hasAttachmentTypes }}
     <div class="btn-group js-attachments-manager" role="group">
         <button class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown">
@@ -9,8 +9,12 @@
         <ul class="dropdown-menu js-attachments-manager">
             {{# attachmentTypes }}
             <li>
-                <a href="{{baseUrl}}admin/object/edit?obj_type={{val}}{{# id }}&obj_id={{ . }}{{/ id }}" data-type="{{val}}"{{# id }} data-id="{{ . }}"{{/ id }} data-title="{{label}}" class="js-add-attachment" target="_blank">
-                    <span class="glyphicon {{glyphicon}}"></span>
+                <a href="{{baseUrl}}admin/object/edit?obj_type={{val}}{{# id }}&obj_id={{ . }}{{/ id }}" data-type="{{val}}"{{# id }} data-id="{{ . }}"{{/ id }} data-title="{{label}}" data-skip-form="{{skipForm}}" class="js-add-attachment" target="_blank">
+                    {{# attachmentOptions.show_icon }}
+                    {{# showIcon }}
+                    <span class="{{faIcon}}"></span>
+                    {{/ showIcon }}
+                    {{/ attachmentOptions.show_icon }}
                     <span class="glyphicon-class">{{label}}</span>
                 </a>
             </li>
@@ -18,8 +22,8 @@
         </ul>
     </div>
     {{/ hasAttachmentTypes }}
-    {{/ readOnly }}
-    {{# showAttachmentPreview }}
+    {{/ attachmentOptions.read_only }}
+    {{# attachmentOptions.show_preview }}
     <div class="btn-group" role="group" aria-label="{{# _t }}Toggle Content Previews{{/ _t }}">
         <button type="button" class="btn btn-default js-attachments-expand" aria-label="{{# _t }}Expand Previews{{/ _t }}">
             <span class="glyphicon glyphicon-collapse-down"></span> {{# _t }}Expand{{/ _t }}
@@ -28,5 +32,5 @@
             <span class="glyphicon glyphicon-collapse-up"></span> {{# _t }}Close{{/ _t }}
         </button>
     </div>
-    {{/ showAttachmentPreview }}
+    {{/ attachmentOptions.show_preview }}
 </div>

--- a/templates/charcoal/admin/widget/attachment/list.mustache
+++ b/templates/charcoal/admin/widget/attachment/list.mustache
@@ -4,10 +4,10 @@
 
     The OBJ has the `attachments` method (@see AttachableAwareTrait)
 }}
-<section class="c-attachments_container js-attachment-container{{^ readOnly }} js-attachment-sortable{{/ readOnly }}">
+<section class="c-attachments_container js-attachment-container{{^ attachmentOptions.read_only }} js-attachment-sortable{{/ attachmentOptions.read_only }}">
     <div role="tablist"
          id="{{ widgetId }}_accordion"
-         class="panel-group js-grid-container{{^ showAttachmentHeading }} js-attachment-preview-only{{/ showAttachmentHeading }}"
+         class="panel-group js-grid-container{{^ attachmentOptions.show_header }} js-attachment-preview-only{{/ attachmentOptions.show_header }}"
          aria-multiselectable="false">
     {{# attachments }}
         {{> charcoal/admin/widget/attachment/object }}

--- a/templates/charcoal/admin/widget/attachment/object.mustache
+++ b/templates/charcoal/admin/widget/attachment/object.mustache
@@ -5,23 +5,27 @@
     @used-by `charcoal/admin/widget/attachment/list`
 --}}
 <article
-        class="panel {{# active }}panel-default{{/ active}}{{^ active }}panel-danger{{/ active}} js-attachment{{# showAttachmentPreview }} content-preview{{/ showAttachmentPreview}}"
+        class="panel {{# active }}panel-default{{/ active}}{{^ active }}panel-danger{{/ active}} js-attachment{{# attachmentOptions.show_preview }} content-preview{{/ attachmentOptions.show_preview}}"
         id="{{ widgetId }}_{{ id }}"
         data-id="{{ id }}"
         data-type="{{ objType }}"
         data-microtype="{{ microType }}"
     {{# attachmentGroup }} data-group="{{ . }}"{{/ attachmentGroup }}>
-    {{# showAttachmentPreview }}
+    {{# attachmentOptions.show_preview }}
         {{> charcoal/admin/widget/attachment/object/collapsible }}
-    {{/ showAttachmentPreview }}
-    {{^ showAttachmentPreview }}
+    {{/ attachmentOptions.show_preview }}
+    {{^ attachmentOptions.show_preview }}
         <header{{^ readOnly }} draggable="true"{{/ readOnly }} id="{{ widgetId }}_heading_{{ id }}" class="panel-heading">
             <h4 class="panel-title">
-                <span class="panel-title-icon glyphicon {{ glyphicon }}"></span>
+                {{# attachmentType }}
+                    {{# showIcon }}
+                        <span class="panel-title-icon {{ faIcon }}"></span>
+                    {{/ showIcon }}
+                {{/ attachmentType }}
                 <a href="object/edit?obj_type={{ type }}&obj_id={{ id }}">{{& heading }}{{^ active }}&mdash; <span class="small">{{# _t }}Disabled{{/ _t }}</span>{{/ active }}</a>
             </h4>
         </header>
-    {{/ showAttachmentPreview }}
+    {{/ attachmentOptions.show_preview }}
     <aside class="panel-actions panel-actions-float btn-toolbar js-attachment-actions" role="toolbar">
         {{> charcoal/admin/widget/attachment/object/actions }}
     </aside>

--- a/templates/charcoal/admin/widget/attachment/object/actions.mustache
+++ b/templates/charcoal/admin/widget/attachment/object/actions.mustache
@@ -1,18 +1,28 @@
 <div class="btn-group" role="group">
-    {{# readOnly }}
-    <button type="button" class="btn btn-default" disabled>
-        <span class="glyphicon {{ glyphicon }}"></span>
-    </button>
-    {{/ readOnly }}
-    {{^ readOnly }}
+    {{# attachmentOptions.read_only }}
+        {{# attachmentOptions.show_icon }}
+        {{# attachmentType }}
+        {{# showIcon }}
+        <button type="button" class="btn btn-default" disabled>
+            <span class="{{ faIcon }}"></span>
+        </button>
+        {{/ showIcon }}
+        {{/ attachmentType }}
+        {{/ attachmentOptions.show_icon }}
+    {{/ attachmentOptions.read_only }}
+    {{^ attachmentOptions.read_only }}
     <button type="button" class="btn {{# active }}btn-primary{{/ active }}{{^ active }}btn-danger{{/ active }} dropdown-toggle" data-toggle="dropdown">
-        {{# showAttachmentHeading }}
+        {{# attachmentOptions.show_header }}
         <span class="btn-label">{{# _t }}Actions{{/ _t }}</span>
-        {{/ showAttachmentHeading }}
-        {{^ showAttachmentHeading }}
-        <span class="glyphicon {{ glyphicon }}">&nbsp;</span>
+        {{/ attachmentOptions.show_header }}
+        {{^ attachmentOptions.show_header }}
+            {{# attachmentType }}
+            {{# showIcon }}
+            <span class="{{ faIcon }}">&nbsp;</span>
+            {{/ showIcon }}
+            {{/ attachmentType }}
         <span class="sr-only">{{# _t }}Actions{{/ _t }}</span>
-        {{/ showAttachmentHeading }}
+        {{/ attachmentOptions.show_header }}
         <span class="caret"></span>
     </button>
     <ul class="dropdown-menu">
@@ -32,5 +42,5 @@
         <li><a href="object/edit?obj_type={{ type }}&obj_id={{ id }}" target="_blank">{{# _t }}Edit Content{{/ _t }}</a></li>
         {{/ isAttachmentContainer }}
     </ul>
-    {{/ readOnly }}
+    {{/ attachmentOptions.read_only }}
 </div>

--- a/templates/charcoal/admin/widget/attachment/object/collapsible.mustache
+++ b/templates/charcoal/admin/widget/attachment/object/collapsible.mustache
@@ -4,20 +4,26 @@
 
     @used-by `charcoal/admin/widget/attachment/object`
 --}}
-<header role="tab"{{^ readOnly }} draggable="true"{{/ readOnly }} id="{{ widgetId }}_heading_{{ id }}" class="panel-heading{{^ showAttachmentHeading }} sr-only{{/ showAttachmentHeading }}">
+<header role="tab"{{^ attachmentOptions.read_only }} draggable="true"{{/ attachmentOptions.read_only }} id="{{ widgetId }}_heading_{{ id }}" class="panel-heading{{^ attachmentOptions.show_header }} sr-only{{/ attachmentOptions.show_header }}">
     <h4 class="panel-title">
-        <span class="panel-title-icon glyphicon {{ glyphicon }}"></span>
+        {{# attachmentOptions.show_icon }}
+        {{# attachmentType }}
+            {{# showIcon }}
+            <span class="panel-title-icon {{ faIcon }}"></span>
+            {{/ showIcon }}
+        {{/ attachmentType }}
+        {{/ attachmentOptions.show_icon }}
         <a role="button"
            href="#{{ widgetId }}_body_{{ id }}"
-           {{# showAttachmentHeading }}class="collapsed"{{/ showAttachmentHeading }}
+           {{# attachmentOptions.show_header }}class="collapsed"{{/ attachmentOptions.show_header }}
            data-toggle="collapse"
            data-parent="#{{ widgetId }}_accordion"
            aria-controls="{{ widgetId }}_body_{{ id }}"
-           aria-expanded="{{^ showAttachmentHeading }}true{{/ showAttachmentHeading }}{{# showAttachmentHeading }}false{{/ showAttachmentHeading }}"
+           aria-expanded="{{# attachmentOptions }}{{^ show_header }}true{{/ show_header }}{{# show_header }}false{{/ show_header }}{{/ attachmentOptions }}"
            >{{& heading }}{{^ active }}&mdash; <em>{{# _t }}Disabled{{/ _t }}</em>{{/ active}}</a>
     </h4>
 </header>
-<section id="{{ widgetId }}_body_{{ id }}" class="panel-collapse collapse{{^ showAttachmentHeading }} in{{/ showAttachmentHeading }}" role="tabpanel" aria-labelledby="{{ widgetId }}_heading_{{ id }}">
+<section id="{{ widgetId }}_body_{{ id }}" class="panel-collapse collapse{{^ attachmentOptions.show_header }} in{{/ attachmentOptions.show_header }}" role="tabpanel" aria-labelledby="{{ widgetId }}_heading_{{ id }}">
     <div class="panel-body">
         {{> $widget_template }}
     </div>

--- a/templates/charcoal/attachment/object/accordion.mustache
+++ b/templates/charcoal/attachment/object/accordion.mustache
@@ -6,7 +6,9 @@
     <ul class="list-group">
     {{# attachments }}
         <li class="list-group-item u-truncate{{^ active }} alert-danger{{/ active}}">
-            <span class="list-group-item-icon glyphicon {{ glyphicon }}"></span>
+            {{# attachmentType }}
+            <span class="list-group-item-icon {{ faIcon }}"></span>
+            {{/ attachmentType }}
             <span class="list-group-item-label">{{& heading }}{{^ active }} &mdash; <span class="small">{{# _t }}Disabled{{/ _t }}</span>{{/ active }}</span>
             {{> charcoal/attachment/object/partial/modify-button }}
         </li>


### PR DESCRIPTION
 - Move attachment's icon from attachment object to attachment widget.
 - Use Font awesome library instead of glyphicon.
 - Use an AttachmentOptions array on the widget to clean the usage and facilitate further expansion.