### PR TITLE
Replace val to value in metadata filters because val is deprecated

### DIFF
--- a/metadata/charcoal/attachment/object/embed.json
+++ b/metadata/charcoal/attachment/object/embed.json
@@ -99,7 +99,7 @@
                 "filters": {
                     "type": {
                         "property": "type",
-                        "val": "charcoal/attachment/object/embed"
+                        "value": "charcoal/attachment/object/embed"
                     }
                 }
             },
@@ -117,7 +117,7 @@
                 "filters": {
                     "type": {
                         "property": "type",
-                        "val": "charcoal/attachment/object/embed"
+                        "value": "charcoal/attachment/object/embed"
                     }
                 }
             }

--- a/metadata/charcoal/attachment/object/file.json
+++ b/metadata/charcoal/attachment/object/file.json
@@ -30,7 +30,7 @@
                 "filters": {
                     "type": {
                         "property": "type",
-                        "val": "charcoal/attachment/object/file"
+                        "value": "charcoal/attachment/object/file"
                     }
                 }
             },
@@ -48,7 +48,7 @@
                 "filters": {
                     "type": {
                         "property": "type",
-                        "val": "charcoal/attachment/object/file"
+                        "value": "charcoal/attachment/object/file"
                     }
                 }
             }

--- a/metadata/charcoal/attachment/object/gallery.json
+++ b/metadata/charcoal/attachment/object/gallery.json
@@ -36,7 +36,7 @@
                 "filters": {
                     "type": {
                         "property": "type",
-                        "val": "charcoal/attachment/object/gallery"
+                        "value": "charcoal/attachment/object/gallery"
                     }
                 }
             },
@@ -53,7 +53,7 @@
                 "filters": {
                     "type": {
                         "property": "type",
-                        "val": "charcoal/attachment/object/gallery"
+                        "value": "charcoal/attachment/object/gallery"
                     }
                 }
             }

--- a/metadata/charcoal/attachment/object/image.json
+++ b/metadata/charcoal/attachment/object/image.json
@@ -38,7 +38,7 @@
                 "filters": {
                     "type": {
                         "property": "type",
-                        "val": "charcoal/attachment/object/image"
+                        "value": "charcoal/attachment/object/image"
                     }
                 }
             },
@@ -56,7 +56,7 @@
                 "filters": {
                     "type": {
                         "property": "type",
-                        "val": "charcoal/attachment/object/image"
+                        "value": "charcoal/attachment/object/image"
                     }
                 }
             }

--- a/metadata/charcoal/attachment/object/link.json
+++ b/metadata/charcoal/attachment/object/link.json
@@ -76,7 +76,7 @@
                 "filters": {
                     "type": {
                         "property": "type",
-                        "val": "charcoal/attachment/object/link"
+                        "value": "charcoal/attachment/object/link"
                     }
                 }
             },
@@ -94,7 +94,7 @@
                 "filters": {
                     "type": {
                         "property": "type",
-                        "val": "charcoal/attachment/object/link"
+                        "value": "charcoal/attachment/object/link"
                     }
                 }
             }

--- a/metadata/charcoal/attachment/object/text.json
+++ b/metadata/charcoal/attachment/object/text.json
@@ -84,7 +84,7 @@
                 "filters": {
                     "type": {
                         "property": "type",
-                        "val": "charcoal/attachment/object/text"
+                        "value": "charcoal/attachment/object/text"
                     }
                 }
             },
@@ -102,7 +102,7 @@
                 "filters": {
                     "type": {
                         "property": "type",
-                        "val": "charcoal/attachment/object/text"
+                        "value": "charcoal/attachment/object/text"
                     }
                 }
             }

--- a/metadata/charcoal/attachment/object/video.json
+++ b/metadata/charcoal/attachment/object/video.json
@@ -22,7 +22,7 @@
                 "filters": {
                     "type": {
                         "property": "type",
-                        "val": "charcoal/attachment/object/video"
+                        "value": "charcoal/attachment/object/video"
                     }
                 }
             },
@@ -40,7 +40,7 @@
                 "filters": {
                     "type": {
                         "property": "type",
-                        "val": "charcoal/attachment/object/video"
+                        "value": "charcoal/attachment/object/video"
                     }
                 }
             }


### PR DESCRIPTION
Replace "val" by "value" in metadata filters because val is deprecated and giving warnings.